### PR TITLE
fix(adapter): handle no clients case without throwing errors

### DIFF
--- a/lib/primus-rooms-redis-adapter.js
+++ b/lib/primus-rooms-redis-adapter.js
@@ -201,8 +201,11 @@ redisAdapter.prototype.broadcast = function broadcast(data, opts, clients) {
       return ~except.indexOf(id) === 0;
     });
     if (adapter.metroplexOmegaSupreme) {
-      var primus = clients[Object.keys(clients)[0]].primus;
-      primus.forward.sparks(ids, transformer(data));
+      var clientsKeys = Object.keys(clients);
+      if (clientsKeys.length) {
+        var primus = clients[clientsKeys[0]].primus;
+        primus.forward.sparks(ids, transformer(data));
+      }
     } else {
       ids.forEach(function(id) {
         var socket = clients[id];


### PR DESCRIPTION
This fixes https://github.com/fadeenk/primus-rooms-redis-adapter/issues/9

I tried to add a test related to this, but apparently it's not possible without some major changes. The error is thrown inside a callback passed to redis (when calling the `send` function) so the error is not visible from the outside when calling `broadcast`, hence I cannot for example use a `expect(fn).to.not.throwError()`. So unless the `broadcast` function provides some callback called after it finishes, I cannot know about this error. Only way would be to listen for uncaught process errors I guess, but I don't feel that's a good thing to add in these tests. On the other hand, adding a callback here would change the API from primus-room plugin, so…

Anyway… let me know if you have any suggestions please.