### PR TITLE
fix(broadcast): use direct primus instance when available

### DIFF
--- a/lib/primus-rooms-redis-adapter.js
+++ b/lib/primus-rooms-redis-adapter.js
@@ -201,9 +201,14 @@ redisAdapter.prototype.broadcast = function broadcast(data, opts, clients) {
       return ~except.indexOf(id) === 0;
     });
     if (adapter.metroplexOmegaSupreme) {
-      var clientsKeys = Object.keys(clients);
-      if (clientsKeys.length) {
-        var primus = clients[clientsKeys[0]].primus;
+      var primus = adapter.primus;
+      if (!primus) {
+        var clientsKeys = Object.keys(clients);
+        if (clientsKeys.length) {
+          primus = clients[clientsKeys[0]].primus;
+        }
+      }
+      if (primus) {
         primus.forward.sparks(ids, transformer(data));
       }
     } else {


### PR DESCRIPTION
When using metroplexOmegaSupreme you need the primus instance to be able to forward messages. But the way it currently tries to get a primus instance is by taking it from the "first client connection" it gets from the primus-rooms' call. The problem with this is that if this particular node has no connections at all (but there are connections on other nodes) this instance won't be able to deliver the message.

This problem can happen on nodes that are just starting to process requests, for example, and it can be ever more probable the more nodes there are (since it will be more likely a node won't have connections because other nodes are taking them).

Primus-rooms(-adapter) doesn't provide a primus instance to adapters in any way, so there is no "Adapter API" to get it. But, since this adapter in particular does ask for an optional primus instance at config time (to enable cleanup logic currently) and it also stores it as an instance variable, we can use that to use `primus.forward()`, at least when it's available. That way, it doesn't matter if there are connections or not, and also the process in that case gets a bit simpler.

This would still be a problem if you don't pass this primus instance, since it's optional, so it would probably be good to maybe add something in the docs explaining this (since currently it only mentions this primus instance in the context of exit cleanup logic).